### PR TITLE
chore: add auth helpers and health check

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,46 +1,7 @@
-import NextAuth from "next-auth"
-import Google from "next-auth/providers/google"
-import LinkedIn from "next-auth/providers/linkedin"
-import { DrizzleAdapter } from "@auth/drizzle-adapter"
-import { db } from "@/db"
-import { Session } from "next-auth"
-import { mockSession, mockUser } from "@/data/mock-auth"
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
 
-const isDevelopment = process.env.NODE_ENV === "development"
+const handler = NextAuth(authOptions);
 
-const handler = NextAuth({
-  adapter: undefined, // Disable database adapter temporarily
-  providers: [
-    Google({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-    LinkedIn({
-      clientId: process.env.LINKEDIN_CLIENT_ID!,
-      clientSecret: process.env.LINKEDIN_CLIENT_SECRET!,
-    }),
-  ],
-  pages: {
-    signIn: "/login",
-    error: "/login",
-  },
-  callbacks: {
-    async session({ session, user }: { session: Session; user: any }) {
-      if (isDevelopment) {
-        return mockSession
-      }
-      if (session.user && user) {
-        session.user.id = user.id
-      }
-      return session
-    },
-    async signIn() {
-      if (isDevelopment) {
-        return true
-      }
-      return true
-    },
-  },
-})
+export const { GET, POST } = handler;
 
-export const { GET, POST } = handler

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+export function GET() {
+  return NextResponse.json({ status: "ok" });
+}
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,43 @@
+import { NextAuthOptions } from "next-auth";
+import Google from "next-auth/providers/google";
+import LinkedIn from "next-auth/providers/linkedin";
+import { Session } from "next-auth";
+import { mockSession } from "@/data/mock-auth";
+
+const isDevelopment = process.env.NODE_ENV === "development";
+
+export const authOptions: NextAuthOptions = {
+  adapter: undefined, // Disable database adapter temporarily
+  providers: [
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+    LinkedIn({
+      clientId: process.env.LINKEDIN_CLIENT_ID!,
+      clientSecret: process.env.LINKEDIN_CLIENT_SECRET!,
+    }),
+  ],
+  pages: {
+    signIn: "/login",
+    error: "/login",
+  },
+  callbacks: {
+    async session({ session, user }: { session: Session; user: any }) {
+      if (isDevelopment) {
+        return mockSession;
+      }
+      if (session.user && user) {
+        session.user.id = (user as any).id;
+      }
+      return session;
+    },
+    async signIn() {
+      if (isDevelopment) {
+        return true;
+      }
+      return true;
+    },
+  },
+};
+

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,9 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "./auth";
+import { User } from "next-auth";
+
+export async function getSessionUser(): Promise<User | null> {
+  const session = await getServerSession(authOptions);
+  return session?.user ?? null;
+}
+


### PR DESCRIPTION
## Summary
- centralize NextAuth configuration for reuse
- add server-side session helper
- expose basic API health endpoint

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (interactive prompt: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68976671015083268ced56a97ec92997